### PR TITLE
Add test coverage for VM expressions, page decode, and lexer edge cases

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = "1.0.89"
 
 [dev-dependencies]
 divan = "0.1.14"
-lexer = { path = "../lexer" }
 
 [[bench]]
 name = "page"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.89"
 
 [dev-dependencies]
 divan = "0.1.14"
+lexer = { path = "../lexer" }
 
 [[bench]]
 name = "page"

--- a/crates/engine/src/page.rs
+++ b/crates/engine/src/page.rs
@@ -505,4 +505,97 @@ mod page_encoder_tests {
 
     //     // TODO: need to be able to read slots!
     // }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+
+        let slot1 = vec![1u8, 2, 3];
+        let slot2 = vec![4u8, 5, 6, 7];
+
+        encoder.add_slot_bytes(slot1.clone()).unwrap();
+        encoder.add_slot_bytes(slot2.clone()).unwrap();
+
+        let page_bytes = encoder.collect();
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+
+        assert_eq!(decoder.try_read_bytes(0).unwrap(), slot1);
+        assert_eq!(decoder.try_read_bytes(1).unwrap(), slot2);
+    }
+
+    #[test]
+    fn test_checksum_passes_for_valid_page() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+        encoder.add_slot_bytes(vec![1u8, 2, 3]).unwrap();
+
+        let page_bytes = encoder.collect();
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+
+        assert!(decoder.check().pass);
+    }
+
+    #[test]
+    fn test_checksum_fails_for_corrupted_page() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+        encoder.add_slot_bytes(vec![1u8, 2, 3]).unwrap();
+
+        let mut page_bytes = encoder.collect();
+        // Flip bits in the first data byte (just after the header).
+        page_bytes[PAGE_HEADER_SIZE_BYTES as usize] ^= 0xFF;
+
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+        assert!(!decoder.check().pass);
+    }
+
+    #[test]
+    fn test_slot_out_of_range_on_empty_page() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+        let page_bytes = encoder.collect();
+
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+        let result = decoder.try_read_bytes(0);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), page::PageDecoderError::SlotOutOfRange);
+    }
+
+    #[test]
+    fn test_slot_out_of_range_beyond_count() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+        encoder.add_slot_bytes(vec![1u8]).unwrap();
+        let page_bytes = encoder.collect();
+
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+
+        assert!(decoder.try_read_bytes(0).is_ok());
+        assert_eq!(
+            decoder.try_read_bytes(1).unwrap_err(),
+            page::PageDecoderError::SlotOutOfRange
+        );
+    }
+
+    #[test]
+    fn test_empty_page_decode_has_zero_slots() {
+        let header = PageHeader::new(page::PageType::Data);
+        let mut encoder = PageEncoder::new(header);
+        let page_bytes = encoder.collect();
+
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+        assert_eq!(decoder.header().allocated_slot_count, 0);
+    }
+
+    #[test]
+    fn test_decode_header_preserves_page_type() {
+        let header = PageHeader::new(page::PageType::Index);
+        let mut encoder = PageEncoder::new(header);
+        let page_bytes = encoder.collect();
+
+        let decoder = page::PageDecoder::from_bytes(&page_bytes);
+        assert_eq!(decoder.header().page_type, page::PageType::Index);
+    }
 }

--- a/crates/engine/src/vm.rs
+++ b/crates/engine/src/vm.rs
@@ -874,178 +874,395 @@ mod vm_tests {
         }
     }
 
-    fn int(n: &str) -> Expr {
-        Expr::Value(Value::Number(n.to_string()))
-    }
-
-    fn str_val(s: &str) -> Expr {
-        Expr::Value(Value::String(s.to_string(), QuoteType::Single))
-    }
-
-    fn binop(left: Expr, op: BinaryOperator, right: Expr) -> Expr {
-        Expr::BinaryOperator {
-            left: Box::new(left),
-            op,
-            right: Box::new(right),
-        }
-    }
-
-    fn const_select(exprs: Vec<Expr>) -> Statement {
-        Statement::Select(SelectExpressionBody {
-            select_item_list: SelectItemList::from(
-                exprs.into_iter().map(SelectItem::new).collect(),
-            ),
+    #[test]
+    fn test_constant_select_integer() {
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![
+                SelectItem::new(Expr::Value(Value::Number("1".to_string()))),
+            ]),
             from_clause: None,
             where_clause: None,
             order_by_clause: None,
             group_by_clause: None,
-        })
-    }
-
-    fn exec(stmt: Statement) -> cli_common::StatementResult {
-        let vm = VirtualMachine::default();
-        vm.execute_statement(&stmt, &storage()).unwrap()
-    }
-
-    #[test]
-    fn test_constant_select_integer() {
-        let result = exec(const_select(vec![int("1")]));
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
     }
 
     #[test]
     fn test_constant_select_add() {
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Plus, int("2"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::Number("2".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(3));
     }
 
     #[test]
     fn test_constant_select_subtract() {
-        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::Minus, int("3"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("5".to_string()))),
+                op: BinaryOperator::Minus,
+                right: Box::new(Expr::Value(Value::Number("3".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(2));
     }
 
     #[test]
     fn test_constant_select_multiply() {
-        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::Multiply, int("4"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("3".to_string()))),
+                op: BinaryOperator::Multiply,
+                right: Box::new(Expr::Value(Value::Number("4".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(12));
     }
 
     #[test]
     fn test_constant_select_divide() {
-        let result = exec(const_select(vec![binop(int("10"), BinaryOperator::Divide, int("2"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("10".to_string()))),
+                op: BinaryOperator::Divide,
+                right: Box::new(Expr::Value(Value::Number("2".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(5));
     }
 
     #[test]
     fn test_constant_select_modulo() {
-        let result = exec(const_select(vec![binop(int("7"), BinaryOperator::Modulo, int("3"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("7".to_string()))),
+                op: BinaryOperator::Modulo,
+                right: Box::new(Expr::Value(Value::Number("3".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
     }
 
     #[test]
     fn test_constant_select_division_by_zero_returns_zero() {
         // Documents current behavior: division by zero silently returns 0.
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Divide, int("0"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Divide,
+                right: Box::new(Expr::Value(Value::Number("0".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(0));
     }
 
     #[test]
     fn test_constant_select_string() {
-        let result = exec(const_select(vec![str_val("hello")]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::Value(
+                Value::String("hello".to_string(), QuoteType::Single),
+            ))]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::String("hello".to_string()));
     }
 
     #[test]
     fn test_constant_select_string_concat() {
-        let result = exec(const_select(vec![binop(
-            str_val("hello"),
-            BinaryOperator::Plus,
-            str_val(" world"),
-        )]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::String("hello".to_string(), QuoteType::Single))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::String(" world".to_string(), QuoteType::Single))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::String("hello world".to_string()));
     }
 
     #[test]
     fn test_constant_select_null() {
-        let result = exec(const_select(vec![Expr::Value(Value::Null)]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![
+                SelectItem::new(Expr::Value(Value::Null)),
+            ]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_null_arithmetic_returns_null() {
-        let result = exec(const_select(vec![binop(
-            int("1"),
-            BinaryOperator::Plus,
-            Expr::Value(Value::Null),
-        )]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::Null)),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_type_mismatch_returns_null() {
         // Int + String is undefined; documents that it returns Null rather than erroring.
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Plus, str_val("x"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(Value::String("x".to_string(), QuoteType::Single))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_true() {
-        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::GreaterThan, int("3"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("5".to_string()))),
+                op: BinaryOperator::GreaterThan,
+                right: Box::new(Expr::Value(Value::Number("3".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_false() {
-        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::GreaterThan, int("5"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("3".to_string()))),
+                op: BinaryOperator::GreaterThan,
+                right: Box::new(Expr::Value(Value::Number("5".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_comparison_less_than() {
-        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::LessThan, int("5"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("3".to_string()))),
+                op: BinaryOperator::LessThan,
+                right: Box::new(Expr::Value(Value::Number("5".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_less_than_or_equal() {
-        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::LessThanOrEqual, int("3"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("3".to_string()))),
+                op: BinaryOperator::LessThanOrEqual,
+                right: Box::new(Expr::Value(Value::Number("3".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_or_equal() {
-        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::GreaterThanOrEqual, int("5"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("5".to_string()))),
+                op: BinaryOperator::GreaterThanOrEqual,
+                right: Box::new(Expr::Value(Value::Number("5".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_equal_true() {
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Equal, int("1"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Equal,
+                right: Box::new(Expr::Value(Value::Number("1".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_equal_false() {
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Equal, int("2"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::Equal,
+                right: Box::new(Expr::Value(Value::Number("2".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_comparison_not_equal_true() {
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::NotEqual, int("2"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::NotEqual,
+                right: Box::new(Expr::Value(Value::Number("2".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_not_equal_false() {
-        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::NotEqual, int("1"))]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::new(Expr::BinaryOperator {
+                left: Box::new(Expr::Value(Value::Number("1".to_string()))),
+                op: BinaryOperator::NotEqual,
+                right: Box::new(Expr::Value(Value::Number("1".to_string()))),
+            })]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_multiple_columns() {
-        let result = exec(const_select(vec![int("1"), int("2"), int("3")]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![
+                SelectItem::new(Expr::Value(Value::Number("1".to_string()))),
+                SelectItem::new(Expr::Value(Value::Number("2".to_string()))),
+                SelectItem::new(Expr::Value(Value::Number("3".to_string()))),
+            ]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
         assert_eq!(result.result_set.rows[0][1], ExprResult::Int(2));
         assert_eq!(result.result_set.rows[0][2], ExprResult::Int(3));
@@ -1053,15 +1270,26 @@ mod vm_tests {
 
     #[test]
     fn test_constant_select_column_name_defaults_to_index() {
-        let result = exec(const_select(vec![int("42")]));
+        let vm = VirtualMachine::default();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![
+                SelectItem::new(Expr::Value(Value::Number("42".to_string()))),
+            ]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.columns[0].name, "Column 0");
     }
 
     #[test]
     fn test_constant_select_column_alias() {
+        let vm = VirtualMachine::default();
         let stmt = Statement::Select(SelectExpressionBody {
             select_item_list: SelectItemList::from(vec![SelectItem::aliased(
-                int("1"),
+                Expr::Value(Value::Number("1".to_string())),
                 Identifier::from("my_col".to_string()),
             )]),
             from_clause: None,
@@ -1069,13 +1297,14 @@ mod vm_tests {
             order_by_clause: None,
             group_by_clause: None,
         });
-        let result = exec(stmt);
+        let result = vm.execute_statement(&stmt, &storage()).unwrap();
         assert_eq!(result.result_set.columns[0].alias, Some("my_col".to_string()));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
     }
 
     #[test]
     fn test_non_constant_select_without_from_returns_error() {
+        let vm = VirtualMachine::default();
         let stmt = Statement::Select(SelectExpressionBody {
             select_item_list: SelectItemList::from(vec![SelectItem::simple_identifier("id")]),
             from_clause: None,
@@ -1083,7 +1312,6 @@ mod vm_tests {
             order_by_clause: None,
             group_by_clause: None,
         });
-        let vm = VirtualMachine::default();
         let result = vm.execute_statement(&stmt, &storage());
         assert!(result.is_err());
     }

--- a/crates/engine/src/vm.rs
+++ b/crates/engine/src/vm.rs
@@ -862,8 +862,10 @@ mod vm_tests {
     use super::VirtualMachine;
     use crate::{buffer_pool::BufferPool, engine::Storage, fm::FileManager};
     use cli_common::ExprResult;
-    use lexer::Lexer;
-    use parser::Parser;
+    use parser::ast::{
+        BinaryOperator, Expr, Identifier, QuoteType, SelectExpressionBody, SelectItem,
+        SelectItemList, Statement, Value,
+    };
 
     fn storage() -> Storage {
         Storage {
@@ -872,159 +874,178 @@ mod vm_tests {
         }
     }
 
-    fn exec(sql: &str) -> cli_common::StatementResult {
-        let storage = storage();
-        let vm = VirtualMachine::default();
-        let buf = String::from(sql);
-        let lex = Lexer::new(&buf).lex();
-        let tokens: Vec<lexer::token::Token> = lex.tokens.into_iter().map(|t| t.token).collect();
-        let mut parser = Parser::new_positionless(tokens, sql);
-        let program = parser.parse().unwrap();
-        match program {
-            parser::ast::Program::Statements(stmts) => {
-                vm.execute_statement(&stmts[0], &storage).unwrap()
-            }
-            _ => panic!("Expected statements"),
+    fn int(n: &str) -> Expr {
+        Expr::Value(Value::Number(n.to_string()))
+    }
+
+    fn str_val(s: &str) -> Expr {
+        Expr::Value(Value::String(s.to_string(), QuoteType::Single))
+    }
+
+    fn binop(left: Expr, op: BinaryOperator, right: Expr) -> Expr {
+        Expr::BinaryOperator {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
         }
+    }
+
+    fn const_select(exprs: Vec<Expr>) -> Statement {
+        Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(
+                exprs.into_iter().map(SelectItem::new).collect(),
+            ),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        })
+    }
+
+    fn exec(stmt: Statement) -> cli_common::StatementResult {
+        let vm = VirtualMachine::default();
+        vm.execute_statement(&stmt, &storage()).unwrap()
     }
 
     #[test]
     fn test_constant_select_integer() {
-        let result = exec("SELECT 1");
+        let result = exec(const_select(vec![int("1")]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
     }
 
     #[test]
     fn test_constant_select_add() {
-        let result = exec("SELECT 1 + 2");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Plus, int("2"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(3));
     }
 
     #[test]
     fn test_constant_select_subtract() {
-        let result = exec("SELECT 5 - 3");
+        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::Minus, int("3"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(2));
     }
 
     #[test]
     fn test_constant_select_multiply() {
-        let result = exec("SELECT 3 * 4");
+        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::Multiply, int("4"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(12));
     }
 
     #[test]
     fn test_constant_select_divide() {
-        let result = exec("SELECT 10 / 2");
+        let result = exec(const_select(vec![binop(int("10"), BinaryOperator::Divide, int("2"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(5));
     }
 
     #[test]
     fn test_constant_select_modulo() {
-        let result = exec("SELECT 7 % 3");
+        let result = exec(const_select(vec![binop(int("7"), BinaryOperator::Modulo, int("3"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
     }
 
     #[test]
     fn test_constant_select_division_by_zero_returns_zero() {
         // Documents current behavior: division by zero silently returns 0.
-        let result = exec("SELECT 1 / 0");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Divide, int("0"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(0));
     }
 
     #[test]
     fn test_constant_select_string() {
-        let result = exec("SELECT 'hello'");
-        assert_eq!(
-            result.result_set.rows[0][0],
-            ExprResult::String("hello".to_string())
-        );
+        let result = exec(const_select(vec![str_val("hello")]));
+        assert_eq!(result.result_set.rows[0][0], ExprResult::String("hello".to_string()));
     }
 
     #[test]
     fn test_constant_select_string_concat() {
-        let result = exec("SELECT 'hello' + ' world'");
-        assert_eq!(
-            result.result_set.rows[0][0],
-            ExprResult::String("hello world".to_string())
-        );
+        let result = exec(const_select(vec![binop(
+            str_val("hello"),
+            BinaryOperator::Plus,
+            str_val(" world"),
+        )]));
+        assert_eq!(result.result_set.rows[0][0], ExprResult::String("hello world".to_string()));
     }
 
     #[test]
     fn test_constant_select_null() {
-        let result = exec("SELECT null");
+        let result = exec(const_select(vec![Expr::Value(Value::Null)]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_null_arithmetic_returns_null() {
-        let result = exec("SELECT 1 + null");
+        let result = exec(const_select(vec![binop(
+            int("1"),
+            BinaryOperator::Plus,
+            Expr::Value(Value::Null),
+        )]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_type_mismatch_returns_null() {
         // Int + String is undefined; documents that it returns Null rather than erroring.
-        let result = exec("SELECT 1 + 'hello'");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Plus, str_val("x"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_true() {
-        let result = exec("SELECT 5 > 3");
+        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::GreaterThan, int("3"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_false() {
-        let result = exec("SELECT 3 > 5");
+        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::GreaterThan, int("5"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_comparison_less_than() {
-        let result = exec("SELECT 3 < 5");
+        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::LessThan, int("5"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_less_than_or_equal() {
-        let result = exec("SELECT 3 <= 3");
+        let result = exec(const_select(vec![binop(int("3"), BinaryOperator::LessThanOrEqual, int("3"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_greater_than_or_equal() {
-        let result = exec("SELECT 5 >= 5");
+        let result = exec(const_select(vec![binop(int("5"), BinaryOperator::GreaterThanOrEqual, int("5"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_equal_true() {
-        let result = exec("SELECT 1 = 1");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Equal, int("1"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_equal_false() {
-        let result = exec("SELECT 1 = 2");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::Equal, int("2"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_comparison_not_equal_true() {
-        let result = exec("SELECT 1 <> 2");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::NotEqual, int("2"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
     }
 
     #[test]
     fn test_constant_select_comparison_not_equal_false() {
-        let result = exec("SELECT 1 <> 1");
+        let result = exec(const_select(vec![binop(int("1"), BinaryOperator::NotEqual, int("1"))]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
     }
 
     #[test]
     fn test_constant_select_multiple_columns() {
-        let result = exec("SELECT 1, 2, 3");
+        let result = exec(const_select(vec![int("1"), int("2"), int("3")]));
         assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
         assert_eq!(result.result_set.rows[0][1], ExprResult::Int(2));
         assert_eq!(result.result_set.rows[0][2], ExprResult::Int(3));
@@ -1032,24 +1053,38 @@ mod vm_tests {
 
     #[test]
     fn test_constant_select_column_name_defaults_to_index() {
-        let result = exec("SELECT 42");
+        let result = exec(const_select(vec![int("42")]));
         assert_eq!(result.result_set.columns[0].name, "Column 0");
     }
 
     #[test]
+    fn test_constant_select_column_alias() {
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::aliased(
+                int("1"),
+                Identifier::from("my_col".to_string()),
+            )]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
+        let result = exec(stmt);
+        assert_eq!(result.result_set.columns[0].alias, Some("my_col".to_string()));
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
+    }
+
+    #[test]
     fn test_non_constant_select_without_from_returns_error() {
-        let storage = storage();
+        let stmt = Statement::Select(SelectExpressionBody {
+            select_item_list: SelectItemList::from(vec![SelectItem::simple_identifier("id")]),
+            from_clause: None,
+            where_clause: None,
+            order_by_clause: None,
+            group_by_clause: None,
+        });
         let vm = VirtualMachine::default();
-        let buf = String::from("SELECT id");
-        let lex = Lexer::new(&buf).lex();
-        let tokens: Vec<lexer::token::Token> =
-            lex.tokens.into_iter().map(|t| t.token).collect();
-        let mut parser = Parser::new_positionless(tokens, "SELECT id");
-        let stmts = match parser.parse().unwrap() {
-            parser::ast::Program::Statements(s) => s,
-            _ => panic!("Expected statements"),
-        };
-        let result = vm.execute_statement(&stmts[0], &storage);
+        let result = vm.execute_statement(&stmt, &storage());
         assert!(result.is_err());
     }
 }

--- a/crates/engine/src/vm.rs
+++ b/crates/engine/src/vm.rs
@@ -856,3 +856,200 @@ impl VirtualMachine {
         ExprResult::Null
     }
 }
+
+#[cfg(test)]
+mod vm_tests {
+    use super::VirtualMachine;
+    use crate::{buffer_pool::BufferPool, engine::Storage, fm::FileManager};
+    use cli_common::ExprResult;
+    use lexer::Lexer;
+    use parser::Parser;
+
+    fn storage() -> Storage {
+        Storage {
+            buffer_pool: BufferPool::default(),
+            file_manager: FileManager::default(),
+        }
+    }
+
+    fn exec(sql: &str) -> cli_common::StatementResult {
+        let storage = storage();
+        let vm = VirtualMachine::default();
+        let buf = String::from(sql);
+        let lex = Lexer::new(&buf).lex();
+        let tokens: Vec<lexer::token::Token> = lex.tokens.into_iter().map(|t| t.token).collect();
+        let mut parser = Parser::new_positionless(tokens, sql);
+        let program = parser.parse().unwrap();
+        match program {
+            parser::ast::Program::Statements(stmts) => {
+                vm.execute_statement(&stmts[0], &storage).unwrap()
+            }
+            _ => panic!("Expected statements"),
+        }
+    }
+
+    #[test]
+    fn test_constant_select_integer() {
+        let result = exec("SELECT 1");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
+    }
+
+    #[test]
+    fn test_constant_select_add() {
+        let result = exec("SELECT 1 + 2");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(3));
+    }
+
+    #[test]
+    fn test_constant_select_subtract() {
+        let result = exec("SELECT 5 - 3");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(2));
+    }
+
+    #[test]
+    fn test_constant_select_multiply() {
+        let result = exec("SELECT 3 * 4");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(12));
+    }
+
+    #[test]
+    fn test_constant_select_divide() {
+        let result = exec("SELECT 10 / 2");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(5));
+    }
+
+    #[test]
+    fn test_constant_select_modulo() {
+        let result = exec("SELECT 7 % 3");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
+    }
+
+    #[test]
+    fn test_constant_select_division_by_zero_returns_zero() {
+        // Documents current behavior: division by zero silently returns 0.
+        let result = exec("SELECT 1 / 0");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(0));
+    }
+
+    #[test]
+    fn test_constant_select_string() {
+        let result = exec("SELECT 'hello'");
+        assert_eq!(
+            result.result_set.rows[0][0],
+            ExprResult::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_constant_select_string_concat() {
+        let result = exec("SELECT 'hello' + ' world'");
+        assert_eq!(
+            result.result_set.rows[0][0],
+            ExprResult::String("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn test_constant_select_null() {
+        let result = exec("SELECT null");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
+    }
+
+    #[test]
+    fn test_constant_select_null_arithmetic_returns_null() {
+        let result = exec("SELECT 1 + null");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
+    }
+
+    #[test]
+    fn test_constant_select_type_mismatch_returns_null() {
+        // Int + String is undefined; documents that it returns Null rather than erroring.
+        let result = exec("SELECT 1 + 'hello'");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Null);
+    }
+
+    #[test]
+    fn test_constant_select_comparison_greater_than_true() {
+        let result = exec("SELECT 5 > 3");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_greater_than_false() {
+        let result = exec("SELECT 3 > 5");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_less_than() {
+        let result = exec("SELECT 3 < 5");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_less_than_or_equal() {
+        let result = exec("SELECT 3 <= 3");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_greater_than_or_equal() {
+        let result = exec("SELECT 5 >= 5");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_equal_true() {
+        let result = exec("SELECT 1 = 1");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_equal_false() {
+        let result = exec("SELECT 1 = 2");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_not_equal_true() {
+        let result = exec("SELECT 1 <> 2");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(true));
+    }
+
+    #[test]
+    fn test_constant_select_comparison_not_equal_false() {
+        let result = exec("SELECT 1 <> 1");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Bool(false));
+    }
+
+    #[test]
+    fn test_constant_select_multiple_columns() {
+        let result = exec("SELECT 1, 2, 3");
+        assert_eq!(result.result_set.rows[0][0], ExprResult::Int(1));
+        assert_eq!(result.result_set.rows[0][1], ExprResult::Int(2));
+        assert_eq!(result.result_set.rows[0][2], ExprResult::Int(3));
+    }
+
+    #[test]
+    fn test_constant_select_column_name_defaults_to_index() {
+        let result = exec("SELECT 42");
+        assert_eq!(result.result_set.columns[0].name, "Column 0");
+    }
+
+    #[test]
+    fn test_non_constant_select_without_from_returns_error() {
+        let storage = storage();
+        let vm = VirtualMachine::default();
+        let buf = String::from("SELECT id");
+        let lex = Lexer::new(&buf).lex();
+        let tokens: Vec<lexer::token::Token> =
+            lex.tokens.into_iter().map(|t| t.token).collect();
+        let mut parser = Parser::new_positionless(tokens, "SELECT id");
+        let stmts = match parser.parse().unwrap() {
+            parser::ast::Program::Statements(s) => s,
+            _ => panic!("Expected statements"),
+        };
+        let result = vm.execute_statement(&stmts[0], &storage);
+        assert!(result.is_err());
+    }
+}

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -929,4 +929,86 @@ mod lexer_tests {
 
         assert_eq!(actual_without_locations, expected);
     }
+
+    #[test]
+    fn test_empty_string_literal() {
+        let str = String::from("''");
+        let lexer = Lexer::new(&str).lex();
+        let actual = to_token_vec_without_locations(lexer.tokens);
+        let expected = vec![
+            Token::Value(Value::SingleQuoted(Slice::new(1, 1))),
+            Token::EOF,
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_comment_at_end_of_file_without_newline() {
+        // A comment as the last token with no trailing newline should lex cleanly.
+        let str = String::from("-- this is a comment");
+        let lexer = Lexer::new(&str).lex();
+        let actual = to_token_vec_without_locations(lexer.tokens);
+        let expected = vec![Token::Comment(Slice::new(0, 20)), Token::EOF];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Critical Lexer Error")]
+    fn test_tab_character_panics() {
+        // Tab is not handled and triggers the stuck-loop guard.
+        let str = String::from("\t");
+        let _ = Lexer::new(&str).lex();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unclosed_string_panics() {
+        // Bug: a string with no closing quote causes an out-of-bounds slice panic.
+        let str = String::from("'hello");
+        let _ = Lexer::new(&str).lex();
+    }
+
+    #[test]
+    fn test_unknown_comparison_operator_stops_lexing_early() {
+        // '!=' is unrecognized; the fallthrough `break` exits the outer loop
+        // immediately, producing no tokens (not even EOF).
+        let str = String::from("!= 1");
+        let lexer = Lexer::new(&str).lex();
+        let actual = to_token_vec_without_locations(lexer.tokens);
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_negative_number_followed_by_operator() {
+        // '-3' should be a single Numeric token, not Minus + Numeric.
+        let str = String::from("-3 + 1");
+        let lexer = Lexer::new(&str).lex();
+        let actual = to_token_vec_without_locations(lexer.tokens);
+        let expected = vec![
+            Token::Numeric(Slice::new(0, 2)),
+            Token::Space,
+            Token::Arithmetic(Arithmetic::Plus),
+            Token::Space,
+            Token::Numeric(Slice::new(5, 6)),
+            Token::EOF,
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_minus_without_following_number_is_arithmetic() {
+        // A standalone '-' not followed by a digit is Arithmetic::Minus.
+        let str = String::from("5 - 3");
+        let lexer = Lexer::new(&str).lex();
+        let actual = to_token_vec_without_locations(lexer.tokens);
+        let expected = vec![
+            Token::Numeric(Slice::new(0, 1)),
+            Token::Space,
+            Token::Arithmetic(Arithmetic::Minus),
+            Token::Space,
+            Token::Numeric(Slice::new(4, 5)),
+            Token::EOF,
+        ];
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
- vm.rs: 20 new tests covering all arithmetic ops, comparisons, string
  concat, null propagation, type mismatches, and the division-by-zero
  behavior (returns 0, not an error)
- page.rs: 6 new tests covering encode→decode round-trips, checksum
  validation on clean and corrupted pages, and SlotOutOfRange errors
- lexer/lib.rs: 6 new tests covering empty string literals, EOF-terminal
  comments, tab-character panic, unclosed-string panic, the early-exit
  bug triggered by '!=', and negative-number tokenization

https://claude.ai/code/session_01Qb49gxGCNWvEFmRd51uXKv